### PR TITLE
feat: 人口推移情報を取得してパースするカスタムフックの実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "next": "14.2.5",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "swr": "2.2.5",
     "zod": "3.23.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      swr:
+        specifier: 2.2.5
+        version: 2.2.5(react@18.3.1)
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -2836,6 +2839,11 @@ packages:
   svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
 
+  swr@2.2.5:
+    resolution: {integrity: sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -2977,6 +2985,11 @@ packages:
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+
+  use-sync-external-store@1.2.2:
+    resolution: {integrity: sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -6354,6 +6367,12 @@ snapshots:
 
   svg-tags@1.0.0: {}
 
+  swr@2.2.5(react@18.3.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 18.3.1
+      use-sync-external-store: 1.2.2(react@18.3.1)
+
   symbol-tree@3.2.4: {}
 
   table@6.8.2:
@@ -6510,6 +6529,10 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  use-sync-external-store@1.2.2(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   util-deprecate@1.0.2: {}
 

--- a/src/components/top-page/graph/index.hook.ts
+++ b/src/components/top-page/graph/index.hook.ts
@@ -1,0 +1,26 @@
+import useSWR from "swr";
+import { z } from "zod";
+
+import { populationResponseSchema } from "@/model/population.model";
+import { PrefectureModel } from "@/model/prefecture.model";
+
+export const usePopulation = (prefCodes: PrefectureModel["prefCode"][]) => {
+  const swrResponse = useSWR<
+    z.infer<typeof populationResponseSchema>[],
+    Error,
+    string[]
+  >(
+    prefCodes.map((prefCode) => `/api/population/${prefCode}`),
+    async (urls) => {
+      const responses = await Promise.all(
+        urls.map((url) => fetch(url).then((res) => res.json())),
+      );
+
+      return responses.map((response) =>
+        populationResponseSchema.parse(response),
+      );
+    },
+  );
+
+  return swrResponse;
+};

--- a/src/model/population.model.ts
+++ b/src/model/population.model.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+
+import { PrefectureModel } from "./prefecture.model";
+
+export const populationType = [
+  {
+    id: "total",
+    label: "総人口",
+  },
+  {
+    id: "young",
+    label: "年少人口",
+  },
+  {
+    id: "productive",
+    label: "生産年齢人口",
+  },
+  {
+    id: "elderly",
+    label: "老年人口",
+  },
+] as const;
+
+export type PopulationType = (typeof populationType)[number]["id"];
+
+export const populationResponseSchema = z.object({
+  data: z.object({
+    message: z.nullable(z.string()),
+    result: z.object({
+      boundaryYear: z.number(),
+      data: z.array(
+        z.object({
+          label: z.string(),
+          data: z.array(
+            z.object({
+              year: z.number(),
+              value: z.number(),
+            }),
+          ),
+        }),
+      ),
+    }),
+  }),
+  prefCode: z.number(),
+});
+
+type PopulationModel = {
+  prefCode: PrefectureModel["prefCode"];
+  boundaryYear: number;
+  data: {
+    [key in PopulationType]: {
+      year: number;
+      value: number;
+    }[];
+  };
+};
+
+export const createPopulationList = (
+  parsedResponses: z.infer<typeof populationResponseSchema>[],
+): PopulationModel[] =>
+  parsedResponses.map((parsedResponse) => {
+    const { boundaryYear, data } = parsedResponse.data.result;
+
+    return {
+      prefCode: parsedResponse.prefCode,
+      boundaryYear,
+      data: Object.fromEntries(
+        populationType.map(({ id, label }) => [
+          id,
+          data.find((d) => d.label === label)!.data,
+        ]),
+      ) as PopulationModel["data"],
+    };
+  });


### PR DESCRIPTION
## 背景・経緯

- APIを実装したのでコンポーネントで使える形に整形するところまで実装する

## 実装内容

- #6 で定義した中間APIにリクエストを送信して人口推移情報を取得する
- 取得した情報をモデルにパースする