### PR TITLE
feat: 都道府県一覧のスタイルを整える

### DIFF
--- a/src/components/top-page/index.module.css
+++ b/src/components/top-page/index.module.css
@@ -1,0 +1,6 @@
+.wrapper {
+  display: flex;
+  width: 100%;
+  height: 100vh;
+  margin: 0 auto;
+}

--- a/src/components/top-page/index.test.tsx
+++ b/src/components/top-page/index.test.tsx
@@ -34,7 +34,7 @@ describe("TopPage", () => {
             prefName: "秋田県",
           },
         ]}
-      />
+      />,
     );
   });
 

--- a/src/components/top-page/index.tsx
+++ b/src/components/top-page/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import styles from "./index.module.css";
 import { Prefectures } from "./prefectures";
 import { Graph } from "./graph";
 
@@ -25,12 +26,13 @@ export const TopPage = ({ prefectures }: Props) => {
   };
 
   return (
-    <main>
+    <main className={styles.wrapper}>
       <Prefectures
         prefectures={prefectures}
         selectedPrefCodes={selectedPrefCodes}
         onClickCheckbox={handleSelectPrefecture}
       />
+
       <Graph prefectures={prefectures} selectedPrefCodes={selectedPrefCodes} />
     </main>
   );

--- a/src/components/top-page/prefectures/index.module.css
+++ b/src/components/top-page/prefectures/index.module.css
@@ -1,3 +1,38 @@
+.wrapper {
+  flex-shrink: 0;
+  width: 120px;
+  height: 100%;
+  padding: 20px 24px;
+  overflow-y: scroll;
+  background-color: ghostwhite;
+}
+
+.list {
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  padding-left: 0;
+}
+
 .item {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  height: 40px;
   list-style-type: none;
+}
+
+.checkbox {
+  width: 20px;
+  height: 20px;
+}
+
+.checkbox:checked {
+  color: #bea7a7;
+  background-color: #222;
+}
+
+.label {
+  font-size: 16px;
+  text-wrap: nowrap;
 }

--- a/src/components/top-page/prefectures/index.test.tsx
+++ b/src/components/top-page/prefectures/index.test.tsx
@@ -39,10 +39,6 @@ describe("Prefectures", () => {
     );
   });
 
-  it("タイトルが表示されること", () => {
-    expect(screen.getByText("都道府県")).toBeVisible();
-  });
-
   it("都道府県が全て表示されること", () => {
     expect(screen.getByText("北海道")).toBeVisible();
     expect(screen.getByText("青森県")).toBeVisible();

--- a/src/components/top-page/prefectures/index.tsx
+++ b/src/components/top-page/prefectures/index.tsx
@@ -13,18 +13,20 @@ export const Prefectures = ({
   selectedPrefCodes,
   onClickCheckbox: handleClickCheckbox,
 }: Props) => (
-  <div>
-    <h2>都道府県</h2>
-    <ul>
+  <div className={styles.wrapper}>
+    <ul className={styles.list}>
       {prefectures.map(({ prefCode, prefName }) => (
         <li className={styles.item} key={prefCode}>
           <input
+            className={styles.checkbox}
             id={prefName}
             type="checkbox"
             checked={selectedPrefCodes.includes(prefCode)}
             onChange={() => handleClickCheckbox(prefCode)}
           />
-          <label htmlFor={prefName}>{prefName}</label>
+          <label className={styles.label} htmlFor={prefName}>
+            {prefName}
+          </label>
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## 背景・経緯

- 都道府県一覧とグラフが同時に見れるようにサイドバー形式で都道府県のチェックボックスを表示する

## 実装内容

- 都道府県一覧のスタイルを整える

<img width="272" alt="image" src="https://github.com/user-attachments/assets/9ebe261c-9548-4157-8fbd-e9d8c7bef9cc">
