### PR TITLE
refactor: 種別切り替えのセレクトボックスを切り出す

### DIFF
--- a/src/components/top-page/graph/index.module.css
+++ b/src/components/top-page/graph/index.module.css
@@ -5,14 +5,3 @@
   width: 100%;
   height: 100%;
 }
-
-.type {
-  display: flex;
-  gap: 8px;
-  justify-content: center;
-  padding: 16px;
-}
-
-.type select {
-  font-size: 16px;
-}

--- a/src/components/top-page/graph/index.tsx
+++ b/src/components/top-page/graph/index.tsx
@@ -8,14 +8,14 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { useState } from "react";
 import palette from "google-palette";
 import { useMediaQuery, useWindowSize } from "usehooks-ts";
 
 import styles from "./index.module.css";
 import { usePopulation } from "./index.hook";
+import { useTypeSelect } from "./type-select/index.hook";
 
-import { createPopulationList, populationType, PopulationType } from "@/model/population.model";
+import { createPopulationList } from "@/model/population.model";
 import { PrefectureModel } from "@/model/prefecture.model";
 
 type Props = {
@@ -25,9 +25,9 @@ type Props = {
 
 export const Graph = ({ prefectures, selectedPrefCodes }: Props) => {
   const { data, error } = usePopulation(selectedPrefCodes);
+  const { selectedPopulationType, render: renderTypeSelect } = useTypeSelect();
   const { height } = useWindowSize();
   const isMobile = useMediaQuery("(max-width: 768px)");
-  const [selectedPopulationType, setSelectedPopulationType] = useState<PopulationType>("total");
 
   if (error) throw error;
 
@@ -37,20 +37,7 @@ export const Graph = ({ prefectures, selectedPrefCodes }: Props) => {
 
   return (
     <div className={styles.wrapper}>
-      <div className={styles.type}>
-        <label htmlFor="population-type">種別</label>
-        <select
-          id="population-type"
-          value={selectedPopulationType}
-          onChange={(event) => setSelectedPopulationType(event.target.value as PopulationType)}
-        >
-          {populationType.map(({ id, label }) => (
-            <option key={id} value={id}>
-              {label}
-            </option>
-          ))}
-        </select>
-      </div>
+      {renderTypeSelect()}
 
       <ResponsiveContainer width="90%" height={isMobile ? height * 0.5 : height - 100}>
         <LineChart width={730} height={500}>

--- a/src/components/top-page/graph/type-select/index.hook.test.tsx
+++ b/src/components/top-page/graph/type-select/index.hook.test.tsx
@@ -1,0 +1,32 @@
+import { render, renderHook, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { useTypeSelect } from "./index.hook";
+
+describe("useTypeSelect", () => {
+  it("totalが初期値として返される", () => {
+    const { result } = renderHook(() => useTypeSelect());
+    expect(result.current.selectedPopulationType).toBe("total");
+  });
+
+  it("render関数によってTypeSelectがレンダリングされる", () => {
+    const { result } = renderHook(() => useTypeSelect());
+    expect(result.current.render).not.toBeNull();
+  });
+
+  describe("TypeSelect", () => {
+    const { result } = renderHook(() => useTypeSelect());
+
+    beforeEach(() => {
+      render(<>{result.current.render()}</>);
+    });
+
+    it("タイトルが表示される", () => {
+      expect(screen.getByText("種別")).toBeVisible();
+    });
+
+    it("セレクトボックスが表示される", () => {
+      expect(screen.getByRole("combobox")).toBeVisible();
+    });
+  });
+});

--- a/src/components/top-page/graph/type-select/index.hook.tsx
+++ b/src/components/top-page/graph/type-select/index.hook.tsx
@@ -1,0 +1,18 @@
+import { useState } from "react";
+
+import { TypeSelect } from ".";
+
+import { PopulationType } from "@/model/population.model";
+
+export const useTypeSelect = () => {
+  const [selectedPopulationType, setSelectedPopulationType] = useState<PopulationType>("total");
+
+  const render = () => (
+    <TypeSelect
+      selectedPopulationType={selectedPopulationType}
+      onClickChange={setSelectedPopulationType}
+    />
+  );
+
+  return { selectedPopulationType, render };
+};

--- a/src/components/top-page/graph/type-select/index.module.css
+++ b/src/components/top-page/graph/type-select/index.module.css
@@ -1,0 +1,10 @@
+.wrapper {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  padding: 16px;
+}
+
+.select {
+  font-size: 16px;
+}

--- a/src/components/top-page/graph/type-select/index.tsx
+++ b/src/components/top-page/graph/type-select/index.tsx
@@ -1,0 +1,26 @@
+import styles from "./index.module.css";
+
+import { PopulationType, populationType } from "@/model/population.model";
+
+type Props = {
+  selectedPopulationType: PopulationType;
+  onClickChange: (populationType: PopulationType) => void;
+};
+
+export const TypeSelect = ({ selectedPopulationType, onClickChange: handleClickChange }: Props) => (
+  <div className={styles.wrapper}>
+    <label htmlFor="population-type">種別</label>
+    <select
+      className={styles.select}
+      id="population-type"
+      value={selectedPopulationType}
+      onChange={(event) => handleClickChange(event.target.value as PopulationType)}
+    >
+      {populationType.map(({ id, label }) => (
+        <option key={id} value={id}>
+          {label}
+        </option>
+      ))}
+    </select>
+  </div>
+);


### PR DESCRIPTION
## 背景・経緯

- 種別切り替えのセレクトボックスとグラフが同一コンポーネントにあり、コンポーネントの粒度として適切でなかった

## 実装内容

- セレクトボックスを切り出す
- 選択されている種別のロジックもセレクトボックス側にカスタムフックとして置く
  - こうすることで `Graph` は選択中の種別がどうやって管理されているかを知らなくて済む
